### PR TITLE
Handle missing products before GTIN lookup

### DIFF
--- a/tp-google-customer-reviews.php
+++ b/tp-google-customer-reviews.php
@@ -113,9 +113,12 @@ function tp_google_customer_reviews_optin( $order_id ) {
     $products = [];
 
     foreach ( $order->get_items() as $item ) {
-        $gtin = wc_get_product( $item->get_product_id() )->get_meta('_gtin');
-        if ( $gtin ) {
-            $products[] = ['gtin' => $gtin];
+        $product = wc_get_product( $item->get_product_id() );
+        if ( $product ) {
+            $gtin = $product->get_meta('_gtin');
+            if ( $gtin ) {
+                $products[] = [ 'gtin' => $gtin ];
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Safely retrieve GTIN only when product exists

## Testing
- `php -l tp-google-customer-reviews.php`


------
https://chatgpt.com/codex/tasks/task_e_6899a9cb82a88327915b860dddbd37ba