### PR TITLE
Improve localization and opt-in script handling

### DIFF
--- a/assets/js/tp-gcr.js
+++ b/assets/js/tp-gcr.js
@@ -1,0 +1,3 @@
+(function(config){
+    window.___gcfg = { lang: config.lang };
+})(tpGcrConfig);


### PR DESCRIPTION
## Summary
- load plugin text domain and cache settings to reduce repeated lookups
- enqueue localized script to set Google Customer Reviews language instead of inline JS
- guard WooCommerce integrations and compute delivery date with WC_DateTime

## Testing
- `php -l tp-google-customer-reviews.php`
- `node --check assets/js/tp-gcr.js`


------
https://chatgpt.com/codex/tasks/task_e_6899ae4577b8832791d4e5dbd7d65a27