### PR TITLE
feat: add integration toggle option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Google Customer Reviews for WooCommerce
 ## Installation
 1. Upload the plugin files to the `/wp-content/plugins` directory or install the plugin through the WordPress plugins screen.
 2. Activate the plugin through the 'Plugins' screen in WordPress.
-3. Go to **Settings -> TP Google Customer Reviews** and enter your Google Merchant ID, choose the language, and set the estimated delivery time.
+3. Go to **Settings -> TP Google Customer Reviews** and enter your Google Merchant ID, choose the language, set the estimated delivery time, and enable or disable the integration as needed.
 
 ## Usage
 Once configured, the plugin adds the Google Customer Reviews opt-in to completed WooCommerce orders and sends review invitations after the estimated delivery time.
@@ -14,7 +14,7 @@ Once configured, the plugin adds the Google Customer Reviews opt-in to completed
 ## Instrukcje (Polski)
 1. Wgraj pliki wtyczki do katalogu `/wp-content/plugins` lub zainstaluj ją z poziomu ekranu Wtyczki w WordPressie.
 2. Aktywuj wtyczkę w panelu WordPress w zakładce **Wtyczki**.
-3. Przejdź do **Ustawienia -> TP Google Customer Reviews**, wpisz swój Google Merchant ID, wybierz język i ustaw przewidywany czas dostawy.
+3. Przejdź do **Ustawienia -> TP Google Customer Reviews**, wpisz swój Google Merchant ID, wybierz język, ustaw przewidywany czas dostawy i włącz lub wyłącz integrację wtyczki.
 
 ## Użycie
 Po konfiguracji wtyczka dodaje formularz zgody Google Customer Reviews do zamówień WooCommerce i wysyła zaproszenia do zostawienia opinii po upływie przewidywanego czasu dostawy.

--- a/languages/tp-gcr-en_US.po
+++ b/languages/tp-gcr-en_US.po
@@ -34,3 +34,7 @@ msgstr "Estimated delivery time (days)"
 msgid "TP Google Customer Reviews for WooCommerce"
 msgstr "TP Google Customer Reviews for WooCommerce"
 
+#: tp-google-customer-reviews.php:76
+msgid "Enable Google Customer Reviews"
+msgstr "Enable Google Customer Reviews"
+

--- a/languages/tp-gcr-pl_PL.po
+++ b/languages/tp-gcr-pl_PL.po
@@ -35,3 +35,7 @@ msgstr "Przewidywany czas dostawy (dni)"
 msgid "TP Google Customer Reviews for WooCommerce"
 msgstr "TP Google Customer Reviews dla WooCommerce"
 
+#: tp-google-customer-reviews.php:76
+msgid "Enable Google Customer Reviews"
+msgstr "Włącz Google Customer Reviews"
+


### PR DESCRIPTION
## Summary
- allow enabling or disabling Google Customer Reviews integration from plugin settings
- centralize option retrieval and reuse cached values in settings fields
- add new translation strings and documentation for integration toggle

## Testing
- `php -l tp-google-customer-reviews.php`

------
https://chatgpt.com/codex/tasks/task_e_6899b6b6e2348327b7f4b707ba25a5fd