### PR TITLE
docs: add bilingual README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,62 @@
-# Google-Customer-Reviews
-Google Customer Reviews for WooCommerce
+# TP Google Customer Reviews for WooCommerce
 
-## Installation
-1. Upload the plugin files to the `/wp-content/plugins` directory or install the plugin through the WordPress plugins screen.
-2. Activate the plugin through the 'Plugins' screen in WordPress.
-3. Go to **Settings -> TP Google Customer Reviews** and enter your Google Merchant ID, choose the language, set the estimated delivery time, and enable or disable the integration as needed.
+## English
 
-## Usage
-Once configured, the plugin adds the Google Customer Reviews opt-in to completed WooCommerce orders and sends review invitations after the estimated delivery time. You can also display a rating badge on the frontend and choose positions for both the badge and the opt-in popup.
+### Overview
+TP Google Customer Reviews integrates Google Customer Reviews with WooCommerce. It displays an opt-in widget after checkout to collect customer feedback and can show a rating badge on your site.
+
+### Requirements
+- WordPress 5.0 or higher
+- PHP 7.0 or higher
+- WooCommerce
+- Google Merchant ID
+
+### Options
+- **Enable Google Customer Reviews** – toggle the integration on or off.
+- **Google Merchant ID** – identifier used to link your shop with Google.
+- **Language** – language code for the opt-in widget.
+- **Estimated delivery time (days)** – number of days after purchase before the review invitation is sent.
+- **Display rating badge** – show a Google rating badge on your pages.
+- **Show badge only on shop pages** – limit the badge to WooCommerce areas.
+- **Badge position** – choose `bottom_left` or `bottom_right`.
+- **Opt-in style** – choose `CENTER_DIALOG`, `BOTTOM_LEFT_DIALOG`, or `BOTTOM_RIGHT_DIALOG`.
+
+### Installation
+1. Upload the plugin to `/wp-content/plugins` or install it via the WordPress plugin screen.
+2. Activate the plugin through the **Plugins** menu.
+3. Go to **Settings → TP Google Customer Reviews** and configure the options.
+
+### Usage
+After configuration, the plugin adds the Google Customer Reviews opt-in script to completed orders, sends review invitations after the estimated delivery time, and optionally displays the rating badge.
 
 ---
 
-## Instrukcje (Polski)
-1. Wgraj pliki wtyczki do katalogu `/wp-content/plugins` lub zainstaluj ją z poziomu ekranu Wtyczki w WordPressie.
-2. Aktywuj wtyczkę w panelu WordPress w zakładce **Wtyczki**.
-3. Przejdź do **Ustawienia -> TP Google Customer Reviews**, wpisz swój Google Merchant ID, wybierz język, ustaw przewidywany czas dostawy i włącz lub wyłącz integrację wtyczki.
+## Polski
 
-## Użycie
-Po konfiguracji wtyczka dodaje formularz zgody Google Customer Reviews do zamówień WooCommerce i wysyła zaproszenia do zostawienia opinii po upływie przewidywanego czasu dostawy. Możliwe jest również wyświetlenie odznaki ocen w wybranym miejscu oraz określenie położenia okna zgody.
+### Przegląd
+TP Google Customer Reviews integruje Google Customer Reviews z WooCommerce. Wyświetla okno zgody po dokonaniu zakupu w celu zbierania opinii klientów i może pokazywać odznakę ocen na stronie.
+
+### Wymagania
+- WordPress 5.0 lub nowszy
+- PHP 7.0 lub nowszy
+- WooCommerce
+- Google Merchant ID
+
+### Opcje
+- **Włącz Google Customer Reviews** – włącza lub wyłącza integrację.
+- **Google Merchant ID** – identyfikator Twojego sklepu w Google.
+- **Język** – kod języka używany przez okno zgody.
+- **Szacowany czas dostawy (dni)** – liczba dni przed wysłaniem zaproszenia do opinii.
+- **Wyświetl odznakę ocen** – pokazuje odznakę Google na stronie.
+- **Pokazuj odznakę tylko w sklepie** – ogranicza odznakę do stron WooCommerce.
+- **Pozycja odznaki** – wybierz `bottom_left` lub `bottom_right`.
+- **Styl okna zgody** – wybierz `CENTER_DIALOG`, `BOTTOM_LEFT_DIALOG` lub `BOTTOM_RIGHT_DIALOG`.
+
+### Instalacja
+1. Wgraj wtyczkę do `/wp-content/plugins` lub zainstaluj ją z poziomu ekranu wtyczek WordPressa.
+2. Aktywuj wtyczkę w menu **Wtyczki**.
+3. Przejdź do **Ustawienia → TP Google Customer Reviews** i skonfiguruj opcje.
+
+### Użycie
+Po konfiguracji wtyczka dodaje skrypt Google Customer Reviews do zamówień, wysyła zaproszenia do opinii po upływie szacowanego czasu dostawy oraz opcjonalnie wyświetla odznakę ocen.
+


### PR DESCRIPTION
## Summary
- document plugin behaviour in a bilingual README
- outline requirements and configuration options for Google Customer Reviews integration

## Testing
- `php -l tp-google-customer-reviews.php`


------
https://chatgpt.com/codex/tasks/task_e_6899c39962c08327affe707e5efc1758