### PR TITLE
Add filters to customize GTIN retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ TP Google Customer Reviews integrates Google Customer Reviews with WooCommerce. 
 ### Usage
 After configuration, the plugin adds the Google Customer Reviews opt-in script to completed orders, sends review invitations after the estimated delivery time, and optionally displays the rating badge.
 
+### Filters
+Use these filters to customize how GTIN values are retrieved from products.
+
+- `tpgcr_gtin_meta_key` – change the meta key used to fetch the GTIN (default `_gtin`).
+- `tpgcr_gtin_value` – modify the GTIN value before it is sent to Google.
+
+```php
+add_filter( 'tpgcr_gtin_meta_key', function ( $meta_key, $product ) {
+    return '_barcode';
+}, 10, 2 );
+
+add_filter( 'tpgcr_gtin_value', function ( $gtin, $product ) {
+    return trim( $gtin );
+}, 10, 2 );
+```
+
 ---
 
 ## Polski
@@ -59,4 +75,20 @@ TP Google Customer Reviews integruje Google Customer Reviews z WooCommerce. Wyś
 
 ### Użycie
 Po konfiguracji wtyczka dodaje skrypt Google Customer Reviews do zamówień, wysyła zaproszenia do opinii po upływie szacowanego czasu dostawy oraz opcjonalnie wyświetla odznakę ocen.
+
+### Filtry
+Wtyczka udostępnia filtry pozwalające dostosować sposób pobierania wartości GTIN z produktu.
+
+- `tpgcr_gtin_meta_key` – zmienia klucz meta używany do pobierania GTIN (domyślnie `_gtin`).
+- `tpgcr_gtin_value` – modyfikuje wartość GTIN przed wysłaniem do Google.
+
+```php
+add_filter( 'tpgcr_gtin_meta_key', function ( $meta_key, $product ) {
+    return '_barcode';
+}, 10, 2 );
+
+add_filter( 'tpgcr_gtin_value', function ( $gtin, $product ) {
+    return trim( $gtin );
+}, 10, 2 );
+```
 

--- a/tp-google-customer-reviews.php
+++ b/tp-google-customer-reviews.php
@@ -289,7 +289,9 @@ function tp_google_customer_reviews_optin( $order_id ) {
     foreach ( $order->get_items() as $item ) {
         $product = wc_get_product( $item->get_product_id() );
         if ( $product ) {
-            $gtin = $product->get_meta('_gtin');
+            $gtin_meta_key = apply_filters( 'tpgcr_gtin_meta_key', '_gtin', $product );
+            $gtin          = $product->get_meta( $gtin_meta_key );
+            $gtin          = apply_filters( 'tpgcr_gtin_value', $gtin, $product );
             if ( $gtin ) {
                 $products[] = [ 'gtin' => $gtin ];
             }


### PR DESCRIPTION
## Summary
- allow customizing the GTIN meta key and value through `tpgcr_gtin_meta_key` and `tpgcr_gtin_value` filters
- document new GTIN filters with usage examples

## Testing
- `php -l tp-google-customer-reviews.php`


------
https://chatgpt.com/codex/tasks/task_e_689ae86a4a248327a4e7db5f13a3475e